### PR TITLE
Use evaluation keys instead GaloisKeys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,7 +163,8 @@ checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 [[package]]
 name = "fhe"
 version = "0.1.0-beta.4"
-source = "git+https://github.com/Janmajayamall/fhe.rs.git?branch=main#2f957b076b634c82b7d5c5238ff64f70ec223802"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43272134651fe0c1263f99f5e71392f92b82aadf45299ea407af23cf0562e338"
 dependencies = [
  "fhe-math",
  "fhe-traits",
@@ -183,7 +184,8 @@ dependencies = [
 [[package]]
 name = "fhe-math"
 version = "0.1.0-beta.4"
-source = "git+https://github.com/Janmajayamall/fhe.rs.git?branch=main#2f957b076b634c82b7d5c5238ff64f70ec223802"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "246019bd16a52e4f3753908191e4e183877e9edfd8126d25782bf877cf92910f"
 dependencies = [
  "crypto-bigint",
  "fhe-traits",
@@ -204,7 +206,8 @@ dependencies = [
 [[package]]
 name = "fhe-traits"
 version = "0.1.0-beta.4"
-source = "git+https://github.com/Janmajayamall/fhe.rs.git?branch=main#2f957b076b634c82b7d5c5238ff64f70ec223802"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9f2c75f3604f35c499e7c2885e4c3476e35c538880e33221869cad7bad745e"
 dependencies = [
  "rand",
 ]
@@ -212,7 +215,8 @@ dependencies = [
 [[package]]
 name = "fhe-util"
 version = "0.1.0-beta.4"
-source = "git+https://github.com/Janmajayamall/fhe.rs.git?branch=main#2f957b076b634c82b7d5c5238ff64f70ec223802"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a196a83c206432425b755950fd6ef1e2e5b81d7995869f68764403320e03a1"
 dependencies = [
  "itertools",
  "num-bigint-dig",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-fhe = { git =  "https://github.com/Janmajayamall/fhe.rs.git", branch = "main" }
-fhe-util = { git =  "https://github.com/Janmajayamall/fhe.rs.git", branch = "main" }
-fhe-traits = { git =  "https://github.com/Janmajayamall/fhe.rs.git", branch = "main" }
-fhe-math = { git =  "https://github.com/Janmajayamall/fhe.rs.git", branch = "main" }
+fhe = "0.1.0-beta.4"
+fhe-util = "0.1.0-beta.4"
+fhe-traits = "0.1.0-beta.4"
+fhe-math = "0.1.0-beta.4"
 rand = "0.8.5"
 itertools = "0.10.5"
 byteorder = "1.4.3"


### PR DESCRIPTION
Maybe there is no need to work with `GaloisKey`'s and protos, and you can use `EvaluationKey`'s directly?

The `main` branch tests fail, so I wasn't sure how to be 100% convinced it didn't introduce regressions, but this fails at the same places :)